### PR TITLE
Create data_ICQ.json

### DIFF
--- a/data/data_ICQ.json
+++ b/data/data_ICQ.json
@@ -1,0 +1,91 @@
+{
+	"s1": [
+		["Matemáticas I", "MAT021", 5, "MAT"],
+		["Introducción a la Física", "FIS100", 3, "FIS"],
+    ["Química y Sociedad", "QUI010", 3, "PC"],
+		["Introducción a la Ingeniería", "IWG101", 2, "PC"].
+    ["Educación Física I", "DEW100", 1, "HUM"]
+	],
+	"s2": [
+  	["Matemáticas II", "MAT022", 5, "MAT", ["MAT021"]],
+ 		["Física General I", "FIS110", 5, "FIS", ["MAT021", "FIS100"]],
+		["Humanístico I", "HRW1", 2, "HUM"],
+    ["Programación", "IWI131", 3, "PC"],		
+		["Educación Física II", "DEW101", 1, "HUM", ["DEW100"]]
+	],
+	"s3": [
+    ["Matemáticas III", "MAT023", 4, "MAT", ["MAT022"]],
+		["Física General II", "FIS120",  4, "FIS", ["MAT022", "FIS110"]],
+    ["Química Básica", "QUI021", 3, "QUI", ["QUI010"]],
+    ["Química de Materiales", "QUI022", 3, "QUI", ["QUI010"]],
+    ["Laboratorio de Química Básica", "QUI103", 3, "QUI"],
+		["Deportes", "DEW0", 1, "HUM", ["DEW101"]]
+	],
+	"s4": [
+		["Matemáticas IV", "MAT024", 4, "MAT", ["MAT023"]],
+		["Física General III", "FIS130", 4, "FIS", ["MAT022", "FIS110"]],
+    ["Química de Procesos", "QUI024", 3, "QUI", ["QUI021"]],
+    ["Química Organica", "QUI134", 4, "QUI", ["QUI021"]],
+    ["Ingles Cientifico Tecnologico I", "HCW310", 1, "HUM"],
+    ["Humanístico I", "HRW1", 2, "HUM"]
+	],
+	"s5": [
+		["Mecánica de Fluidos", "IWQ210", 4, "ICQ", ["FIS110"]],
+    ["Física General IV", "FIS140", 4, "FIS", ["FIS130", "FIS120"]],
+		["Termodinámica", "IWQ111", 4, "ICQ", ["QUI024"]],
+		["Bioquímica", "QUI250", 3, "QUI", ["QUI134"]],
+		["Metalurgia y Minerales", "ILC204", 3, "PC", ["FIS110"]]
+	],
+	"s6": [
+		["Transferencia de Calor", "IWQ222", 5, "ICQ", ["IWQ221", "IWQ111"]],
+		["Fenomenos de Transporte", "ILQ230", 4, "ICQ", ["IWQ221", "IWQ111","MAT024"]],
+		["Termodinamica para Ingeniero Químico", "ILQ212", 4, "ICQ", ["IWQ111"]],
+		["Laboratorio de Sintesis", "QUI236", 4, "QUI", ["QUI134", "QUI022", "QUI103"]],
+    ["Ingles Cientifico Tecnologico II", "HCW311", 1, "HUM", ["HCW310"]]
+	],
+	"s7": [
+		["Transferencia de Materia", "IWQ223", 5, "ICQ", ["IWQ222", "ILQ212"]],
+		["Diseño de Reactores", "ILQ261", 4, "ICQ",["ILQ230", "FIS140", "IWQ222"]],
+		["Analisis y Diseño de Experimentos Industriales", "IWQ214", 3, "ICQ", ["IWQ111"]],
+		["Analisis Instrumental", "QUI325", 3, "QUI", ["QUI134", "QUI022"]],
+		["Electrotecnia Básica", "ELI271", 3, "PC", ["MAT023", "FIS120"]],
+	],
+	"s8": [
+		["Fundamento del Control Industrial", "IWQ350", 4, "ICQ", ["IWQ223"]],	
+		["Gestión de Investigación de Operaciones", "ILN250", 4, "IND", ["ELO204"]],
+		["Electivo 1", "ICQ1", 3, "EL"],
+		["Introducción a la Microbiologia", "IWQ261", 3, "ICQ"],
+    ["Economia I-A", "IWN170", 3, "IND", ["MAT023"]],
+    ["Taller de Ingeniería Química", "IWQ382", 1, "ICQ"]
+	],
+	"s9": [
+		["Análisis de Procesos Químicos", "ICQ373", 4, "ICQ", ["IWQ223", "ILN250"]],
+		["Laboratorio de Procesos", "ICQ228", 4, "ICQ", ["IWQ223", "IWQ214"]],
+    ["Ingeniería Ambiental", "IWQ364", 3, "ICQ"],
+    ["Dibujo y Taller Mecánico", "IWM179", 4, "PC"],
+ 		["Informacion y Control Financiero", "IWN270", 3, "IND", ["IWN170"]],
+    ["Taller de Ingeniería Química II","IWQ386", 1, "ICQ", ["IWQ382"]]
+	],
+	"s10": [
+		["Diseño de Procesos", "ICQ341", 4, "MO", ["IWQ224", "ILQ261", "ICQ373"]],
+		["Laboratorio de investigación", "ICQ392", 4, "ICQ", ["IWQ224", "IWQ214"]],
+		["Electivo II", "ICQ2", 3, "HUM"],
+    ["Fundamentos del Diseño", "ICM286", 3, "PC", ["IWM179"]],
+    ["Administración General", "IWN261", 3, "IND"], 
+		["Seminario de Ingeniería Química", "ICQ383", 1, "ICQ"]
+	],
+	"s11": [
+		["Proyectos", "ICQ381", 4, "IND", ["ICQ373", "ICQ341"]],
+		["Industria Quimica Chilena", "IWQ240", 3, "ICQ", ["ICQ341"]],
+		["Electivo III", "ICQ3", 3, "EL"],
+    ["Administración de la Producción", "ICN345", 3, "IND", ["ILN250"]],
+		["Supervisión de Personal", "IWQ374", 3, "ICQ", ["IWN261"]],
+	],
+	"s12": [
+		["Proyectos Especificos","ELO308", 6, "ICQ", ["ELO307"]],
+		["Electivo IV", "ICQ4", 3, "EL"],
+		["Administración de la Calidad", "IWQ272", 2, "IND", ["IWQ214"]],
+    ["Humanístico 3", "HRW3", 2, "HUM"]
+    
+	]
+}

--- a/data/data_ICQ.json
+++ b/data/data_ICQ.json
@@ -2,49 +2,49 @@
 	"s1": [
 		["Matemáticas I", "MAT021", 5, "MAT"],
 		["Introducción a la Física", "FIS100", 3, "FIS"],
-    ["Química y Sociedad", "QUI010", 3, "PC"],
+		["Química y Sociedad", "QUI010", 3, "PC"],
 		["Introducción a la Ingeniería", "IWG101", 2, "PC"].
-    ["Educación Física I", "DEW100", 1, "HUM"]
+		["Educación Física I", "DEW100", 1, "HUM"]
 	],
 	"s2": [
-  	["Matemáticas II", "MAT022", 5, "MAT", ["MAT021"]],
+		["Matemáticas II", "MAT022", 5, "MAT", ["MAT021"]],
  		["Física General I", "FIS110", 5, "FIS", ["MAT021", "FIS100"]],
 		["Humanístico I", "HRW1", 2, "HUM"],
-    ["Programación", "IWI131", 3, "PC"],		
+		["Programación", "IWI131", 3, "PC"],		
 		["Educación Física II", "DEW101", 1, "HUM", ["DEW100"]]
 	],
 	"s3": [
-    ["Matemáticas III", "MAT023", 4, "MAT", ["MAT022"]],
+		["Matemáticas III", "MAT023", 4, "MAT", ["MAT022"]],
 		["Física General II", "FIS120",  4, "FIS", ["MAT022", "FIS110"]],
-    ["Química Básica", "QUI021", 3, "QUI", ["QUI010"]],
-    ["Química de Materiales", "QUI022", 3, "QUI", ["QUI010"]],
-    ["Laboratorio de Química Básica", "QUI103", 3, "QUI"],
+		["Química Básica", "QUI021", 3, "QUI", ["QUI010"]],
+		["Química de Materiales", "QUI022", 3, "QUI", ["QUI010"]],
+		["Laboratorio de Química Básica", "QUI103", 3, "QUI"],
 		["Deportes", "DEW0", 1, "HUM", ["DEW101"]]
 	],
 	"s4": [
 		["Matemáticas IV", "MAT024", 4, "MAT", ["MAT023"]],
 		["Física General III", "FIS130", 4, "FIS", ["MAT022", "FIS110"]],
-    ["Química de Procesos", "QUI024", 3, "QUI", ["QUI021"]],
-    ["Química Organica", "QUI134", 4, "QUI", ["QUI021"]],
-    ["Ingles Cientifico Tecnologico I", "HCW310", 1, "HUM"],
-    ["Humanístico I", "HRW1", 2, "HUM"]
+		["Química de Procesos", "QUI024", 3, "QUI", ["QUI021"]],
+		["Química Organica", "QUI134", 4, "QUI", ["QUI021"]],
+		["Ingles Cientifico Tecnologico I", "HCW310", 1, "HUM"],
+		["Humanístico I", "HRW1", 2, "HUM"]
 	],
 	"s5": [
-		["Mecánica de Fluidos", "IWQ210", 4, "ICQ", ["FIS110"]],
-    ["Física General IV", "FIS140", 4, "FIS", ["FIS130", "FIS120"]],
-		["Termodinámica", "IWQ111", 4, "ICQ", ["QUI024"]],
+		["Mecánica de Fluidos", "IWQ210", 4, "OPU", ["FIS110"]],
+		["Física General IV", "FIS140", 4, "FIS", ["FIS130", "FIS120"]],
+		["Termodinámica", "IWQ111", 4, "OPU", ["QUI024"]],
 		["Bioquímica", "QUI250", 3, "QUI", ["QUI134"]],
 		["Metalurgia y Minerales", "ILC204", 3, "PC", ["FIS110"]]
 	],
 	"s6": [
-		["Transferencia de Calor", "IWQ222", 5, "ICQ", ["IWQ221", "IWQ111"]],
-		["Fenomenos de Transporte", "ILQ230", 4, "ICQ", ["IWQ221", "IWQ111","MAT024"]],
-		["Termodinamica para Ingeniero Químico", "ILQ212", 4, "ICQ", ["IWQ111"]],
+		["Transferencia de Calor", "IWQ222", 5, "OPU", ["IWQ221", "IWQ111"]],
+		["Fenomenos de Transporte", "ILQ230", 4, "OPU", ["IWQ221", "IWQ111","MAT024"]],
+		["Termodinamica para Ingeniero Químico", "ILQ212", 4, "OPU", ["IWQ111"]],
 		["Laboratorio de Sintesis", "QUI236", 4, "QUI", ["QUI134", "QUI022", "QUI103"]],
-    ["Ingles Cientifico Tecnologico II", "HCW311", 1, "HUM", ["HCW310"]]
+		["Ingles Cientifico Tecnologico II", "HCW311", 1, "HUM", ["HCW310"]]
 	],
 	"s7": [
-		["Transferencia de Materia", "IWQ223", 5, "ICQ", ["IWQ222", "ILQ212"]],
+		["Transferencia de Materia", "IWQ223", 5, "OPU", ["IWQ222", "ILQ212"]],
 		["Diseño de Reactores", "ILQ261", 4, "ICQ",["ILQ230", "FIS140", "IWQ222"]],
 		["Analisis y Diseño de Experimentos Industriales", "IWQ214", 3, "ICQ", ["IWQ111"]],
 		["Analisis Instrumental", "QUI325", 3, "QUI", ["QUI134", "QUI022"]],
@@ -55,37 +55,37 @@
 		["Gestión de Investigación de Operaciones", "ILN250", 4, "IND", ["ELO204"]],
 		["Electivo 1", "ICQ1", 3, "EL"],
 		["Introducción a la Microbiologia", "IWQ261", 3, "ICQ"],
-    ["Economia I-A", "IWN170", 3, "IND", ["MAT023"]],
-    ["Taller de Ingeniería Química", "IWQ382", 1, "ICQ"]
+		["Economia I-A", "IWN170", 3, "IND", ["MAT023"]],
+		["Taller de Ingeniería Química", "IWQ382", 1, "TIT"]
 	],
 	"s9": [
 		["Análisis de Procesos Químicos", "ICQ373", 4, "ICQ", ["IWQ223", "ILN250"]],
 		["Laboratorio de Procesos", "ICQ228", 4, "ICQ", ["IWQ223", "IWQ214"]],
-    ["Ingeniería Ambiental", "IWQ364", 3, "ICQ"],
-    ["Dibujo y Taller Mecánico", "IWM179", 4, "PC"],
+		["Ingeniería Ambiental", "IWQ364", 3, "TIT"],
+		["Dibujo y Taller Mecánico", "IWM179", 4, "PC"],
  		["Informacion y Control Financiero", "IWN270", 3, "IND", ["IWN170"]],
-    ["Taller de Ingeniería Química II","IWQ386", 1, "ICQ", ["IWQ382"]]
+		["Taller de Ingeniería Química II","IWQ386", 1, "TIT", ["IWQ382"]]
 	],
 	"s10": [
-		["Diseño de Procesos", "ICQ341", 4, "MO", ["IWQ224", "ILQ261", "ICQ373"]],
+		["Diseño de Procesos", "ICQ341", 4, "ICQ", ["IWQ224", "ILQ261", "ICQ373"]],
 		["Laboratorio de investigación", "ICQ392", 4, "ICQ", ["IWQ224", "IWQ214"]],
-		["Electivo II", "ICQ2", 3, "HUM"],
-    ["Fundamentos del Diseño", "ICM286", 3, "PC", ["IWM179"]],
-    ["Administración General", "IWN261", 3, "IND"], 
-		["Seminario de Ingeniería Química", "ICQ383", 1, "ICQ"]
+		["Electivo II", "ICQ2", 3, "EL"],
+		["Fundamentos del Diseño", "ICM286", 3, "PC", ["IWM179"]],
+		["Administración General", "IWN261", 3, "IND"], 
+		["Seminario de Ingeniería Química", "ICQ383", 1, "TIT"]
 	],
 	"s11": [
 		["Proyectos", "ICQ381", 4, "IND", ["ICQ373", "ICQ341"]],
 		["Industria Quimica Chilena", "IWQ240", 3, "ICQ", ["ICQ341"]],
 		["Electivo III", "ICQ3", 3, "EL"],
-    ["Administración de la Producción", "ICN345", 3, "IND", ["ILN250"]],
+		["Administración de la Producción", "ICN345", 3, "IND", ["ILN250"]],
 		["Supervisión de Personal", "IWQ374", 3, "ICQ", ["IWN261"]],
 	],
 	"s12": [
 		["Proyectos Especificos","ELO308", 6, "ICQ", ["ELO307"]],
 		["Electivo IV", "ICQ4", 3, "EL"],
 		["Administración de la Calidad", "IWQ272", 2, "IND", ["IWQ214"]],
-    ["Humanístico 3", "HRW3", 2, "HUM"]
+		["Humanístico 3", "HRW3", 2, "HUM"]
     
 	]
 }


### PR DESCRIPTION
Mala 5110 de Ingeniería Civil Química, falta cambiar las clasificaciones de los ramos, (hay muchos ICQ), para ello esperaré a que se apruebe la lista de colores.
Falta agregar una forma de poner requisitos complementarios (ejemplo Ramo A ó Ramo B) y poner de requisito la cantidad de créditos aprobados. Hay unos 6 ramos que están incompletos por ello.